### PR TITLE
Debug.warn breaks IE

### DIFF
--- a/src/Emitter.js
+++ b/src/Emitter.js
@@ -370,9 +370,7 @@
 			{
 				if(this.particleImages[i].baseTexture != this.particleImages[i - 1].baseTexture)
 				{
-					if(window.Debug)
-						Debug.warn("PixiParticles: using particle textures from different images may hinder performance in WebGL");
-					else if(window.console)
+					if (window.console)
 						console.warn("PixiParticles: using particle textures from different images may hinder performance in WebGL");
 					break;
 				}


### PR DESCRIPTION
The IE Debug object doesn't have a warn function. So it throws and breaks execution. IE supports console.log however. I don't think there is a reason to look for the Debug object at all. 